### PR TITLE
Remove reviewers from Dependabot configuration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @arnested

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,12 +6,8 @@ updates:
   schedule:
     interval: daily
     timezone: Europe/Copenhagen
-  reviewers:
-  - "arnested"
 - package-ecosystem: docker
   directory: "/"
   schedule:
     interval: daily
     timezone: Europe/Copenhagen
-  reviewers:
-  - "arnested"


### PR DESCRIPTION
See https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/
